### PR TITLE
fix: firebase-tools “Error: certificate has expired”

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,20 +4,21 @@ FROM node:11.5-alpine
 LABEL maintainer="nohitme@gmail.com"
 
 # variables
-ENV HUGO_VERSION 0.53
+ENV HUGO_VERSION 0.62.2
+ENV FIREBASECLI_VERSION 7.11.0
 
 # install hugo
 RUN set -x && \
-  apk add --update --upgrade --no-cache wget ca-certificates && \
-  # make sure we have up-to-date certificates
-  update-ca-certificates && \
-  cd /tmp &&\
-  wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -O hugo.tar.gz && \
-  tar xzf hugo.tar.gz && \
-  mv hugo /usr/bin/hugo && \
-  rm -r * && \
-  # don't delete ca-certificates pacakge here since it remove all certs too
-  apk del --purge wget && \
-  # install firebase-cli
-  # use --unsafe-perm to solve the issue: https://github.com/firebase/firebase-tools/issues/372
-  npm install -g firebase-tools --unsafe-perm
+    apk add --update --upgrade --no-cache wget ca-certificates && \
+    # make sure we have up-to-date certificates
+    update-ca-certificates && \
+    cd /tmp &&\
+    wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -O hugo.tar.gz && \
+    tar xzf hugo.tar.gz && \
+    mv hugo /usr/bin/hugo && \
+    rm -r * && \
+    # don't delete ca-certificates pacakge here since it remove all certs too
+    apk del --purge wget && \
+    # install firebase-cli
+    # use --unsafe-perm to solve the issue: https://github.com/firebase/firebase-tools/issues/372
+    npm install -g firebase-tools@${FIREBASECLI_VERSION} --unsafe-perm

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:11.5-alpine
 LABEL maintainer="nohitme@gmail.com"
 
 # variables
-ENV HUGO_VERSION 0.62.2
+ENV HUGO_VERSION 0.53
 ENV FIREBASECLI_VERSION 7.11.0
 
 # install hugo
@@ -22,3 +22,4 @@ RUN set -x && \
     # install firebase-cli
     # use --unsafe-perm to solve the issue: https://github.com/firebase/firebase-tools/issues/372
     npm install -g firebase-tools@${FIREBASECLI_VERSION} --unsafe-perm
+


### PR DESCRIPTION
## TL;DR

* Update firebase-tools to avoid error.

## Description

firebase-tools execution failed with `certificate has expired.`

This is due to firebase-tools in docker image is too old.

> https://stackoverflow.com/questions/59621948/firebase-tools-error-certificate-has-expired